### PR TITLE
Fix issue on leaving camera screen

### DIFF
--- a/lib/screens/observation_page.dart
+++ b/lib/screens/observation_page.dart
@@ -154,7 +154,6 @@ class _ObservationPageState extends State<ObservationPage> {
         selectedDate = widget.photoMeta!.time;
         this.observation!.time = selectedDate;
       }
-      print('Going to _loadMetaData');
       _loadMetaData();
     } else {
       selectedDate = this.observation!.time;
@@ -314,9 +313,6 @@ class _ObservationPageState extends State<ObservationPage> {
                               const SizedBox(width: 10),
                               Expanded(
                                 child: TextFormField(
-                                  // initialValue: (this.observation!.latinName==null)
-                                  //     ? ''
-                                  //     : this.observation!.latinName,
                                   controller: _latinNameController,
                                   textAlign: TextAlign.center,
                                   enabled: false,

--- a/lib/screens/upload/upload_page.dart
+++ b/lib/screens/upload/upload_page.dart
@@ -36,6 +36,8 @@ class _UploadPageState extends State<UploadPage> {
 
     if (tempFile != null) {
       _imageFile = File(tempFile.path);
+    } else {  // Set imageFile to null if user pressed cancel in camera
+      _imageFile = null;
     }
   }
 
@@ -47,7 +49,6 @@ class _UploadPageState extends State<UploadPage> {
 
   @override
   Widget build(BuildContext context) {
-    // final user = Provider.of<User?>(context);
     return Scaffold(
         appBar: AppBar(
           title: Text('Upload'),


### PR DESCRIPTION
## Issue
After taking a photo and entering `observation_page`, that photo is persistent while that observation is discarded without saving. The user will keep going to `observation_page` with the same photo when they press cancel in camera. 

## Reason
The error occurs since `_imageFile` is not `None` after the first picture is taken. Even if user cancels camera and `_pickImage` didn't do anything, previous `_imageFile` is still persistent and will navigate user to `observation_page`. 

## Solution
Set `_imageFile` to null if user pressed cancel in camera (`pickImage` returns null)